### PR TITLE
Found bug in RVI20U32 that was requiring version 2.2 of C extension b…

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -30,6 +30,15 @@
     },
     {
       "type": "rdbg",
+      "name": "AC100-CRD",
+      "request": "launch",
+      "command": "bundle exec rake",
+      "script": "gen:proc_crd_pdf[AC100]",
+      "args": [],
+      "askParameters": false
+    },
+    {
+      "type": "rdbg",
       "name": "MockCRD",
       "request": "launch",
       "command": "bundle exec rake",

--- a/Rakefile
+++ b/Rakefile
@@ -354,7 +354,7 @@ namespace :test do
     Generally, this tries to build all artifacts
   DESC
   task :nightly do
-    Rake::Task["regress"].invoke
+    Rake::Task["test:regress"].invoke
     Rake::Task["portfolios"].invoke
     puts
     puts "Nightly regression test PASSED"

--- a/arch/ext/Sv32.yaml
+++ b/arch/ext/Sv32.yaml
@@ -7,7 +7,13 @@ long_name: 32-bit virtual address translation (3 level)
 description: 32-bit virtual address translation (3 level)
 type: privileged
 versions:
+  - version: "1.11.0"
+    state: ratified
+    ratification_date: null
   - version: "1.12.0"
     state: ratified
     ratification_date: null
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+  - version: "1.13.0"
+    state: ratified
+    ratification_date: null

--- a/arch/ext/Sv39.yaml
+++ b/arch/ext/Sv39.yaml
@@ -7,7 +7,13 @@ long_name: 39-bit virtual address translation (3 level)
 description: 39-bit virtual address translation (3 level)
 type: privileged
 versions:
+  - version: "1.11.0"
+    state: ratified
+    ratification_date: null
   - version: "1.12.0"
     state: ratified
     ratification_date: null
     url: https://github.com/riscv/riscv-isa-manual/releases/download/Priv-v1.12/riscv-privileged-20211203.pdf
+  - version: "1.13.0"
+    state: ratified
+    ratification_date: null

--- a/arch/ext/Sv48.yaml
+++ b/arch/ext/Sv48.yaml
@@ -7,6 +7,12 @@ long_name: 48-bit virtual address translation (4 level)
 description: 48-bit virtual address translation (4 level)
 type: privileged
 versions:
+  - version: "1.11.0"
+    state: ratified
+    ratification_date: null
+    requires:
+      name: Sv39
+      version: ">= 1.11"
   - version: "1.12.0"
     state: ratified
     ratification_date: null
@@ -14,3 +20,9 @@ versions:
     requires:
       name: Sv39
       version: ">= 1.12"
+  - version: "1.13.0"
+    state: ratified
+    ratification_date: null
+    requires:
+      name: Sv39
+      version: ">= 1.13"

--- a/arch/ext/Sv57.yaml
+++ b/arch/ext/Sv57.yaml
@@ -7,6 +7,12 @@ long_name: 57-bit virtual address translation (5 level)
 description: 57-bit virtual address translation (5 level)
 type: privileged
 versions:
+  - version: "1.11.0"
+    state: ratified
+    ratification_date: null
+    requires:
+      name: Sv48
+      version: ">= 1.11"
   - version: "1.12.0"
     state: ratified
     ratification_date: null
@@ -14,3 +20,9 @@ versions:
     requires:
       name: Sv48
       version: ">= 1.12"
+  - version: "1.13.0"
+    state: ratified
+    ratification_date: null
+    requires:
+      name: Sv48
+      version: ">= 1.13"

--- a/arch/profile/MP-S-64.yaml
+++ b/arch/profile/MP-S-64.yaml
@@ -34,7 +34,7 @@ extensions:
   Sv48:
     presence:
       optional: transitory
-    version: "= 1.11"
+    version: "= 1.12"
     note: Made this a transitory option
   Xmock:
     presence: mandatory

--- a/arch/profile/RVA22S64.yaml
+++ b/arch/profile/RVA22S64.yaml
@@ -26,6 +26,9 @@ extensions:
   Svinval:
     presence: mandatory
     version: "~> 1.0"
+  Sv48:
+    presence: optional
+    version: "~> 1.12"
   Sv57:
     presence: optional
     version: "~> 1.12"

--- a/arch/profile/RVB23S64.yaml
+++ b/arch/profile/RVB23S64.yaml
@@ -184,14 +184,14 @@ extensions:
   Sv48:
     presence:
       optional: expansion
-    version: "~>1.0"
+    version: "~>1.13"
     note: |
       Page-based 48-bit virtual-memory system
 
   Sv57:
     presence:
       optional: expansion
-    version: "~>1.0"
+    version: "~>1.13"
     note: |
       Page-based 57-bit virtual-memory system
 

--- a/arch/profile/RVI20U32.yaml
+++ b/arch/profile/RVI20U32.yaml
@@ -36,7 +36,7 @@ extensions:
     version: "= 2.1"
   C:
     presence: optional
-    version: "= 2.2"
+    version: "= 2.0"
   D:
     presence: optional
     version: "= 2.2"

--- a/backends/portfolio/templates/ext_appendix.adoc.erb
+++ b/backends/portfolio/templates/ext_appendix.adoc.erb
@@ -3,6 +3,7 @@
 == Extension Details
 <% portfolio_design.in_scope_ext_reqs.each do |ext_req| -%>
 <% ext = arch.extension(ext_req.name) -%>
+<% min_ext_ver = ext_req.min_satisfying_ext_ver -%>
 
 <%= anchor_for_udb_doc_ext(ext_req.name) %>
 === Extension <%= ext_req.name %> +
@@ -63,32 +64,34 @@
 --
 <% end -%>
 
-// TODO: GitHub issue 92: Use version specified by each profile.
-<% unless portfolio_design.in_scope_instructions.empty? -%>
+<% insts = min_ext_ver.in_scope_instructions(portfolio_design) -%>
+<% unless insts.empty? -%>
 ==== Instructions
 
-The following instructions are added by this extension:
+The following <%= insts.size %> instructions are added by extension version <%= min_ext_ver.version_str %>
+(the minimum version of this extension that satifies the extension requirement).
 
 [cols="1,3"]
 |===
-<% portfolio_design.in_scope_instructions.each do |inst| -%>
+<% insts.each do |inst| -%>
 | <%= link_to_udb_doc_inst(inst.name) %>
 | *<%= inst.long_name %>*
 <% end -%>
 |===
 <% end -%>
 
-// TODO: GitHub issue 92: Use version specified by each profile.
-<% unless portfolio_design.in_scope_csrs.empty? -%>
+<% csrs = min_ext_ver.in_scope_csrs(portfolio_design) -%>
+<% unless csrs.empty? -%>
 ==== CSRs
 
-The following CSRs are added by this extension:
+The following <%= csrs.size %> CSRs are added by extension version <%= min_ext_ver.version_str %>
+(the minimum version of this extension that satifies the extension requirement).
 
 [%autowidth]
 |===
 | Name | Long Name | Address | Mode
 
-<% portfolio_design.in_scope_csrs.sort_by(&:name).each do |csr| -%>
+<% csrs.sort_by(&:name).each do |csr| -%>
 | <%= link_to_udb_doc_csr(csr.name) %>
 | <%= csr.long_name %>
 | <%= "0x#{csr.address.to_s(16)}" %>

--- a/backends/proc_ctp/tasks.rake
+++ b/backends/proc_ctp/tasks.rake
@@ -42,7 +42,7 @@ Dir.glob("#{$root}/arch/proc_cert_model/*.yaml") do |f|
     #sh "git submodule update --init ext/docs-resources 2>&1"
 
     # Pull in the latest version of the csc-riscv-isa-manual.
-    sh "cd ext/csc-riscv-isa-manual; git fetch; git merge origin/main 2>&1"
+    #sh "cd ext/csc-riscv-isa-manual; git fetch; git merge origin/main 2>&1"
 
     # Pull in the latest version of the docs-resources.
     #sh "cd ext/docs-resources; git fetch; git merge origin/main 2>&1"

--- a/lib/arch_obj_models/extension.rb
+++ b/lib/arch_obj_models/extension.rb
@@ -622,12 +622,33 @@ class ExtensionRequirement
     @presence = presence.freeze
   end
 
-  # @return [Array<ExtensionVersion>] The list of extension versions that satisfy this extension requirement
+  # @return [Array<ExtensionVersion>] The list of extension versions that satisfy this extension requirement.
+  #                                   If none, returns an empty array.
   def satisfying_versions
     return @satisfying_versions unless @satisfying_versions.nil?
 
     @satisfying_versions = @ext.versions.select { |v| satisfied_by?(v) }
   end
+
+  # @return [ExtensionVersion] The minimum extension version that satifies this extension requirement.
+  #                            If none, raises an error.
+  def min_satisfying_ext_ver
+    if satisfying_versions.empty?
+      warn "Extension requirement '#{self}' cannot be met by any available extension version. Available versions:"
+      if @ext.versions.empty?
+        warn "  none"
+      else
+        @ext.versions.each do |ext_ver|
+          warn "  #{ext_ver}"
+        end
+      end
+
+      raise "Cannot satisfy extension requirement '#{self}'"
+    end
+
+    satisfying_versions.min
+  end
+
 
   # @overload
   #   @param extension_version [ExtensionVersion] A specific extension version


### PR DESCRIPTION
…ut only 2.0 exists. Also, test:nightly was calling task regress but it has to call test:regress. Not sure how this was working in upstream.